### PR TITLE
Sum of pegs in corner fix

### DIFF
--- a/src/GameController.py
+++ b/src/GameController.py
@@ -1,7 +1,7 @@
 import time
 
 from game_problem.Heuristic import WeightedHeuristic, SumOfPegsInCornerHeuristic, AverageManhattanToCornerHeuristic, \
-    AverageEuclideanToCornerHeuristic, MaxManhattanToCornerHeuristic
+    AverageEuclideanToCornerHeuristic, MaxManhattanToCornerHeuristic, EnsuredNormalizedHeuristic
 from players.GraphicsHumanPlayer import GraphicsHumanPlayer
 from players.MinimaxAIPlayer import MinimaxAIPlayer
 from players.RandomPlayer import RandomPlayer
@@ -20,10 +20,10 @@ class GameController:
         # self.players = [GraphicsHumanPlayer(self.gui), MinimaxAIPlayer(self.problem, 2, 6, verbose=verbose)]
 
         heuristic1 = WeightedHeuristic([
-            (SumOfPegsInCornerHeuristic(), 0.1),
-            (AverageManhattanToCornerHeuristic(), 0.3),
-            (AverageEuclideanToCornerHeuristic(), 0.4),
-            (MaxManhattanToCornerHeuristic(), 0.2),
+            (EnsuredNormalizedHeuristic(SumOfPegsInCornerHeuristic()), 0.1),
+            (EnsuredNormalizedHeuristic(AverageManhattanToCornerHeuristic()), 0.3),
+            (EnsuredNormalizedHeuristic(AverageEuclideanToCornerHeuristic()), 0.4),
+            (EnsuredNormalizedHeuristic(MaxManhattanToCornerHeuristic()), 0.2),
         ])
         self.players = [
             MinimaxAIPlayer(self.problem, 1, 4, heuristic1, verbose=verbose),

--- a/src/game/State.py
+++ b/src/game/State.py
@@ -22,4 +22,4 @@ class State:
                 and self.peg == other.peg and np.array_equal(self.board.matrix, other.board.matrix))
 
     def __hash__(self):
-        return hash((str(self.board.matrix), self.player, self.mode, self.peg))
+        return hash((bytes(self.board.matrix), self.player, self.mode, self.peg))

--- a/src/game_problem/Heuristic.py
+++ b/src/game_problem/Heuristic.py
@@ -88,6 +88,20 @@ class NoneHeuristic(Heuristic):
         return 0
 
 
+class EnsuredNormalizedHeuristic(Heuristic):
+    """
+    Utility to verify that the inner heuristic is normalized.
+    Usage: EnsuredNormalizedHeuristic(SomeOtherHeuristic()).eval(state, player)
+    """
+    def __init__(self, inner_heuristic: Heuristic):
+        self.inner_heuristic = inner_heuristic
+
+    def eval(self, state: State, player: int) -> float:
+        value = self.inner_heuristic.eval(state, player)
+        assert -0.001 <= value <= 1, f'{type(self.inner_heuristic).__name__}: Assertion -0.001 <= {value} <= 1 Failed'
+        return value
+
+
 class WeightedHeuristic(Heuristic):
     def __init__(self, weighted_heuristics: List[Tuple[Heuristic, float]]):
         self.weighted_heuristics = weighted_heuristics

--- a/src/game_problem/Heuristic.py
+++ b/src/game_problem/Heuristic.py
@@ -105,6 +105,9 @@ class EnsuredNormalizedHeuristic(Heuristic):
 class WeightedHeuristic(Heuristic):
     def __init__(self, weighted_heuristics: List[Tuple[Heuristic, float]]):
         self.weighted_heuristics = weighted_heuristics
+        total_weights = sum(weight for _, weight in weighted_heuristics)
+        if total_weights != 1:
+            raise ValueError(f'Total weights must be 1')
 
     def eval(self, state: State, player: int) -> float:
         total = 0

--- a/src/game_problem/Heuristic.py
+++ b/src/game_problem/Heuristic.py
@@ -111,9 +111,9 @@ class AverageManhattanToCornerHeuristic(Heuristic):
 class SumOfPegsInCornerHeuristic(Heuristic):
     def eval(self, state: State, player: int) -> float:
         """
-        Consider the sum of pegs of the player - normalize the sum by the peg count for each player - scaled by weight
+        Consider the sum of pegs of the player - normalize the sum by the peg count for each player
         """
-        peg_count = (state.board.triangle_size - 1) * state.board.triangle_size / 2
+        peg_count = (state.board.triangle_size + 1) * state.board.triangle_size / 2
         return sum_player_pegs(state.board, player) / peg_count
 
 

--- a/src/players/MinimaxAIPlayer.py
+++ b/src/players/MinimaxAIPlayer.py
@@ -151,6 +151,9 @@ class MinimaxAIPlayer(Player):
         # state_value = state
         state_value = hash(state)
 
+        if state_value in self._state_history_set:
+            return
+
         self._state_history_set.add(state_value)
         self._state_history_queue.append(state_value)
         if len(self._state_history_set) > self.history_size:

--- a/tests/test_evaluation_function.py
+++ b/tests/test_evaluation_function.py
@@ -1,4 +1,5 @@
 import unittest
+
 import numpy as np
 from parameterized import parameterized
 
@@ -6,7 +7,7 @@ from game.Board import Board
 from game.State import State
 from game_problem.ChineseCheckers import ChineseCheckers
 from game_problem.Heuristic import average_manhattan_to_corner, AverageManhattanToCornerHeuristic, Heuristic, \
-    SumOfPegsInCornerHeuristic, AverageEuclideanToCornerHeuristic, MaxManhattanToCornerHeuristic, NoneHeuristic
+    AverageEuclideanToCornerHeuristic, MaxManhattanToCornerHeuristic, NoneHeuristic, SumOfPegsInCornerHeuristic
 from players.MinimaxAIPlayer import MinimaxAIPlayer
 
 
@@ -116,3 +117,19 @@ class TestEvaluationFunction(unittest.TestCase):
         avg_manhattan1 = average_manhattan_to_corner(state1.board, 2)
         avg_manhattan2 = average_manhattan_to_corner(state2.board, 2)
         self.assertTrue(avg_manhattan1 < avg_manhattan2)
+
+    def test_sum_of_pegs_in_corner_heuristic(self):
+        sut = SumOfPegsInCornerHeuristic()
+        state = State(Board(2, matrix=np.array([
+            [0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 1],
+            [0, 0, 0, 1, 0],
+            [2, 0, 0, 0, 0],
+            [2, 2, 0, 0, 0],
+        ])))
+
+        result_player_1 = sut.eval(state, player=1)
+        result_player_2 = sut.eval(state, player=2)
+
+        self.assertEqual(2 / 3, result_player_1)
+        self.assertEqual(3 / 3, result_player_2)


### PR DESCRIPTION
The heuristic for counting how many pegs there are in the opposing corner was not calculating correctly the total number of pegs of a player.
